### PR TITLE
Fix error in config comment

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -68,7 +68,7 @@ AuctionHouseBot.ListedItemLevelRestrict.ExceptionItemIDs =
 #    AuctionHouseBot.<faction>.MinItems
 #    AuctionHouseBot.<faction>.MaxItems
 #        The minimum and maximum number of items to post on that auction house
-#    Default: 15000 for both
+#    Default: 20000 for each faction
 #
 #    AuctionHouseBot.<faction>.BidInterval
 #        How long to wait between bidding


### PR DESCRIPTION
Just a minor typo fix regarding the default min/max AH items (looks like it's actually 20,000 for all three "factions"). Thanks a bunch for your fork, btw; it's much more user-friendly.