### PR TITLE
Adding ilevel value multiplier.

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -197,6 +197,11 @@ AuctionHouseBot.PriceMultiplier.Quality.Legendary = 3
 AuctionHouseBot.PriceMultiplier.Quality.Artifact = 3
 AuctionHouseBot.PriceMultiplier.Quality.Heirloom = 3
 
+# Multiplier applied to item level when determining auction price
+# Final multiplier = itemLevel * this value
+# Default: 0.1
+AuctionHouseBot.PriceMultiplier.ItemLevel = 0.1
+
 ###############################################################################
 #    AuctionHouseBot.RandomStackRatio.*
 #        Used to determine how often a stack of the class will be single or randomly-size stacked when posted

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -165,11 +165,17 @@ AuctionHouseBot.PriceMinimumCenterBase.Glyph = 1000
 AuctionHouseBot.PriceMinimumCenterBase.OverrideItems = 
 
 ###############################################################################
-#    AuctionHouseBot.PriceMultiplier.*
+#    AuctionHouseBot.PriceMultiplier.Category.*
+#    AuctionHouseBot.PriceMultiplier.Quality.*
 #        Category/Quality-level modifier values for the prices of items, which can be
 #        represented as decimal numbers, and must be > 0.  Keep in mind that
 #		 the pricing algorithm has many steps to it and this is just a tuning
 #        modifier.
+#
+#    AuctionHouseBot.PriceMultiplier.ItemLevel.*
+#        Multiplier applied to item level when determining auction price
+#        Final multiplier = itemLevel * this value.  Set to 0 (or less) to disable.
+#        Default: 0 (Disabled)
 ###############################################################################
 
 AuctionHouseBot.PriceMultiplier.Category.Consumable = 1
@@ -197,11 +203,7 @@ AuctionHouseBot.PriceMultiplier.Quality.Legendary = 3
 AuctionHouseBot.PriceMultiplier.Quality.Artifact = 3
 AuctionHouseBot.PriceMultiplier.Quality.Heirloom = 3
 
-# Multiplier applied to item level when determining auction price
-# Final multiplier = itemLevel * this value
-# Default: 0.1
-# Set to 0 to disable this multiplier.
-AuctionHouseBot.PriceMultiplier.ItemLevel = 0.1
+AuctionHouseBot.PriceMultiplier.ItemLevel = 0
 
 ###############################################################################
 #    AuctionHouseBot.RandomStackRatio.*

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -200,6 +200,7 @@ AuctionHouseBot.PriceMultiplier.Quality.Heirloom = 3
 # Multiplier applied to item level when determining auction price
 # Final multiplier = itemLevel * this value
 # Default: 0.1
+# Set to 0 to disable this multiplier.
 AuctionHouseBot.PriceMultiplier.ItemLevel = 0.1
 
 ###############################################################################

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -170,7 +170,6 @@ void AuctionHouseBot::calculateItemValue(ItemTemplate const* itemProto, uint64& 
         outBuyoutPrice *= itemProto->ItemLevel * ItemLevelPriceMultiplier;
     }
 
-
     // If a vendor sells this item, make the price at least that high
     if (itemProto->SellPrice > outBuyoutPrice)
         outBuyoutPrice = itemProto->SellPrice;
@@ -881,6 +880,7 @@ void AuctionHouseBot::InitializeConfiguration()
     PriceMultiplierQualityLegendary = sConfigMgr->GetOption<float>("AuctionHouseBot.PriceMultiplier.Quality.Legendary", 3);
     PriceMultiplierQualityArtifact = sConfigMgr->GetOption<float>("AuctionHouseBot.PriceMultiplier.Quality.Artifact", 3);
     PriceMultiplierQualityHeirloom = sConfigMgr->GetOption<float>("AuctionHouseBot.PriceMultiplier.Quality.Heirloom", 3);
+	ItemLevelPriceMultiplier = sConfigMgr->GetOption<float>("AuctionHouseBot.PriceMultiplier.ItemLevel", 0);
 
     // Price minimums
     PriceMinimumCenterBaseConsumable = sConfigMgr->GetOption<uint32>("AuctionHouseBot.PriceMinimumCenterBase.Consumable",1000);
@@ -922,9 +922,6 @@ void AuctionHouseBot::InitializeConfiguration()
     NeutralConfig.SetMaxItems(sConfigMgr->GetOption<uint32>("AuctionHouseBot.Neutral.MaxItems", 15000));
     NeutralConfig.SetBiddingInterval(sConfigMgr->GetOption<uint32>("AuctionHouseBot.Neutral.BidInterval", 1));
     NeutralConfig.SetBidsPerInterval(sConfigMgr->GetOption<uint32>("AuctionHouseBot.Neutral.BidsPerInterval", 1));
-
-    ItemLevelPriceMultiplier = sConfigMgr->GetOption<float>("AuctionHouseBot.PriceMultiplier.ItemLevel", 1.0f);
-
 }
 
 uint32 AuctionHouseBot::GetRandomStackValue(std::string configKeyString, uint32 defaultValue)

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -165,10 +165,11 @@ void AuctionHouseBot::calculateItemValue(ItemTemplate const* itemProto, uint64& 
     outBuyoutPrice *= classPriceMultiplier;
 
     // Apply item level multiplier
-    if (itemProto->ItemLevel > 0)
+    if (ItemLevelPriceMultiplier > 0.0f && itemProto->ItemLevel > 0)
     {
-    outBuyoutPrice *= itemProto->ItemLevel * ItemLevelPriceMultiplier;
+        outBuyoutPrice *= itemProto->ItemLevel * ItemLevelPriceMultiplier;
     }
+
 
     // If a vendor sells this item, make the price at least that high
     if (itemProto->SellPrice > outBuyoutPrice)

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -164,6 +164,12 @@ void AuctionHouseBot::calculateItemValue(ItemTemplate const* itemProto, uint64& 
     outBuyoutPrice *= qualityPriceMultplier;
     outBuyoutPrice *= classPriceMultiplier;
 
+    // Apply item level multiplier
+    if (itemProto->ItemLevel > 0)
+    {
+    outBuyoutPrice *= itemProto->ItemLevel * ItemLevelPriceMultiplier;
+    }
+
     // If a vendor sells this item, make the price at least that high
     if (itemProto->SellPrice > outBuyoutPrice)
         outBuyoutPrice = itemProto->SellPrice;
@@ -915,6 +921,9 @@ void AuctionHouseBot::InitializeConfiguration()
     NeutralConfig.SetMaxItems(sConfigMgr->GetOption<uint32>("AuctionHouseBot.Neutral.MaxItems", 15000));
     NeutralConfig.SetBiddingInterval(sConfigMgr->GetOption<uint32>("AuctionHouseBot.Neutral.BidInterval", 1));
     NeutralConfig.SetBidsPerInterval(sConfigMgr->GetOption<uint32>("AuctionHouseBot.Neutral.BidsPerInterval", 1));
+
+    ItemLevelPriceMultiplier = sConfigMgr->GetOption<float>("AuctionHouseBot.PriceMultiplier.ItemLevel", 1.0f);
+
 }
 
 uint32 AuctionHouseBot::GetRandomStackValue(std::string configKeyString, uint32 defaultValue)

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -223,6 +223,8 @@ private:
     uint32 PriceMinimumCenterBaseMisc;
     uint32 PriceMinimumCenterBaseGlyph;
     std::unordered_map<uint32, uint64> PriceMinimumCenterBaseOverridesByItemID;
+    float ItemLevelPriceMultiplier;
+
 
     AHBConfig AllianceConfig;
     AHBConfig HordeConfig;


### PR DESCRIPTION
## Changes Proposed:
- Adding an additional value multiplier based on item level, with conf adjustment.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Helps make some values more realistic instead of the same values for high and low level items in the same category.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- I'm using it currently in my own server. Tested changing the conf setting to different weights and disabling it by setting the weight to 0.