### PR TITLE
Add Buy/Sell cycle timing variance + Add BuyCandidatesPerBuyCycle variance

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -16,7 +16,8 @@
 #        the AuctionHouseMgr.cpp file.
 #        Value can be a single number in order to wait X cycles between buying
 #        and selling, or a pair of numbers separated by a ':' to wait a random 
-#        number of cycles between X and Y before buying and selling. (e.g. 3:15 )
+#        number of cycles between X and Y before buying and selling (e.g. 3:15 to 
+#        wait 3-15 minutes between cycles).
 #    Default: 1
 #
 #    AuctionHouseBot.EnableSeller
@@ -142,11 +143,14 @@ AuctionHouseBot.Neutral.MaxItems = 15000
 #        How many to items to price and attempt to buy.  Note, this number of
 #        items will be selected from each of the auction house types (Alliance,
 #        Horde, Neutral).  Meaning if you set this as 10, then up to 10 items
-#        from will be selected (total of 30).  Whole numbers only.  Very large
-#        values can impact server performance, and is generally not neccessary.
-#        This runs every minute (which is the auction house update loop time, 
-#        defined by azerothcore core inside the AuctionHouseMgr.cpp file).
-#    Default: 1 (1 item per auction house is considered per minute)
+#        from each AH will be selected (total of 30).  Whole numbers only.
+#        Very large values can impact server performance, and is generally 
+#        not neccessary. This runs once every Buy/Sell cycle as defined 
+#        by AuctionHouseBot.AuctionHouseManagerCyclesBetweenBuyOrSell.
+#        Value can be a single number in order to consider buying X items each
+#        Buy/Sell cycle, or a pair of numbers separated by a ':' to consider 
+#        buying a random number between X and Y items. (e.g. 1:5 to consider 1-5 items)
+#    Default: 1 (1 item per auction house is considered per Buy/Sell cycle)
 #
 #    AuctionHouseBot.Buyer.AcceptablePriceModifier
 #        The buyer bot calculates item prices the same way the selling

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -11,10 +11,13 @@
 #    Default: false (disabled)
 #
 #    AuctionHouseBot.AuctionHouseManagerCyclesBetweenBuyOrSell
-#        How many cycles to wait between executing any buying or selling logic
-#        - At this time, the AzerothCore has it set as 1 minute inside the
-#          AuctionHouseMgr.cpp file
-#    Default 1 (once per AuctionHouseMgr.cpp update cycle)
+#        How many cycles to wait between executing any buying and selling logic.
+#        At this time, AzerothCore waits 1 minute between cycles as defined by
+#        the AuctionHouseMgr.cpp file.
+#        Value can be a single number in order to wait X cycles between buying
+#        and selling, or a pair of numbers separated by a ':' to wait a random 
+#        number of cycles between X and Y before buying and selling. (e.g. 3:15 )
+#    Default: 1
 #
 #    AuctionHouseBot.EnableSeller
 #        Enable/Disable the part of AHBot that puts items up for auction

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -42,6 +42,7 @@ AuctionHouseBot::AuctionHouseBot() :
     SellingBotEnabled(false),
     BuyingBotEnabled(false),
     CyclesBetweenBuyOrSellMin(1),
+    CyclesBetweenBuyOrSell(1),
     CyclesBetweenBuyOrSellMax(1),
     MaxBuyoutPriceInCopper(1000000000),
     BuyoutVariationReducePercent(0.15f),
@@ -1176,9 +1177,10 @@ void AuctionHouseBot::Update()
 
     // Only update if the update cycle has been hit
     LastCycleCount++;
-    if (LastCycleCount < urand(CyclesBetweenBuyOrSellMin, CyclesBetweenBuyOrSellMax))
+    if (LastCycleCount < CyclesBetweenBuyOrSell)
         return;
     LastCycleCount = 0;
+    CyclesBetweenBuyOrSell = urand(CyclesBetweenBuyOrSellMin, CyclesBetweenBuyOrSellMax);
 
     // Randomly select the bot to load, and load it
     uint32 botIndex = urand(0, AHCharacters.size() - 1);
@@ -1470,6 +1472,7 @@ void AuctionHouseBot::SetCyclesBetweenBuyOrSell()
 {
     std::string cyclesConfigString = sConfigMgr->GetOption<std::string>("AuctionHouseBot.AuctionHouseManagerCyclesBetweenBuyOrSell", "1");
     GetConfigMinAndMax(cyclesConfigString, CyclesBetweenBuyOrSellMin, CyclesBetweenBuyOrSellMax);
+    CyclesBetweenBuyOrSell = urand(CyclesBetweenBuyOrSellMin, CyclesBetweenBuyOrSellMax);
 }
 
 void AuctionHouseBot::SetBuyingBotBuyCandidatesPerBuyCycle()

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -41,7 +41,8 @@ AuctionHouseBot::AuctionHouseBot() :
     debug_Out_Filters(false),
     SellingBotEnabled(false),
     BuyingBotEnabled(false),
-    CyclesBetweenBuyOrSell(1),
+    CyclesBetweenBuyOrSellMin(1),
+    CyclesBetweenBuyOrSellMax(1),
     MaxBuyoutPriceInCopper(1000000000),
     BuyoutVariationReducePercent(0.15f),
     BuyoutVariationAddPercent(0.25f),
@@ -1173,7 +1174,7 @@ void AuctionHouseBot::Update()
 
     // Only update if the update cycle has been hit
     LastCycleCount++;
-    if (LastCycleCount < CyclesBetweenBuyOrSell)
+    if (LastCycleCount < urand(CyclesBetweenBuyOrSellMin, CyclesBetweenBuyOrSellMax))
         return;
     LastCycleCount = 0;
 
@@ -1226,7 +1227,7 @@ void AuctionHouseBot::InitializeConfiguration()
     AddCharacters(charString);
 
     // Buyer & Seller core properties
-    CyclesBetweenBuyOrSell = sConfigMgr->GetOption<uint32>("AuctionHouseBot.AuctionHouseManagerCyclesBetweenBuyOrSell", 1);
+    SetCyclesBetweenBuyOrSell();
     ItemsPerCycle = sConfigMgr->GetOption<uint32>("AuctionHouseBot.ItemsPerCycle", 75);
     MaxBuyoutPriceInCopper = sConfigMgr->GetOption<uint32>("AuctionHouseBot.MaxBuyoutPriceInCopper", 1000000000);
     BuyoutVariationReducePercent = sConfigMgr->GetOption<float>("AuctionHouseBot.BuyoutVariationReducePercent", 0.15f);
@@ -1461,6 +1462,26 @@ uint32 AuctionHouseBot::GetRandomStackIncrementValue(std::string configKeyString
         stackIncrementValue = defaultValue;
     }
     return stackIncrementValue;
+}
+
+void AuctionHouseBot::SetCyclesBetweenBuyOrSell()
+{
+    std::string cyclesConfigString = sConfigMgr->GetOption<std::string>("AuctionHouseBot.AuctionHouseManagerCyclesBetweenBuyOrSell", "1");
+    size_t pos = cyclesConfigString.find(':');
+    if (pos != std::string::npos)
+    {
+        CyclesBetweenBuyOrSellMin = std::stoi(cyclesConfigString.substr(0, pos));
+        CyclesBetweenBuyOrSellMax = std::stoi(cyclesConfigString.substr(pos + 1));
+
+        if (CyclesBetweenBuyOrSellMin < 1)
+            CyclesBetweenBuyOrSellMin = 1;
+        if (CyclesBetweenBuyOrSellMax < CyclesBetweenBuyOrSellMin)
+            CyclesBetweenBuyOrSellMax = CyclesBetweenBuyOrSellMin;
+    }
+    else
+    {
+        CyclesBetweenBuyOrSellMin = CyclesBetweenBuyOrSellMax = std::stoi(cyclesConfigString);
+    }
 }
 
 void AuctionHouseBot::AddCharacters(std::string characterGUIDString)

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -128,15 +128,16 @@ private:
 
     bool SellingBotEnabled;
     bool BuyingBotEnabled;
-    int CyclesBetweenBuyOrSellMin;
-    int CyclesBetweenBuyOrSellMax;
+    uint32 CyclesBetweenBuyOrSellMin;
+    uint32 CyclesBetweenBuyOrSellMax;
     uint32 MaxBuyoutPriceInCopper;
     float BuyoutVariationReducePercent;
     float BuyoutVariationAddPercent;
     float BidVariationHighReducePercent;
     float BidVariationLowReducePercent;
     float BuyoutBelowVendorVariationAddPercent;
-    uint32 BuyingBotBuyCandidatesPerBuyCycle;
+    uint32 BuyingBotBuyCandidatesPerBuyCycleMin;
+    uint32 BuyingBotBuyCandidatesPerBuyCycleMax;
     uint32 ListingExpireTimeInSecondsMin;
     uint32 ListingExpireTimeInSecondsMax;
     float BuyingBotAcceptablePriceModifier;
@@ -272,7 +273,7 @@ private:
     FactionSpecificAuctionHouseConfig HordeConfig;
     FactionSpecificAuctionHouseConfig NeutralConfig;
 
-    int LastCycleCount;
+    uint32 LastCycleCount;
     int ActiveListMultipleItemID;
     int RemainingListMultipleCount;
 
@@ -292,6 +293,8 @@ public:
     uint32 GetRandomStackValue(std::string configKeyString, uint32 defaultValue);
     uint32 GetRandomStackIncrementValue(std::string configKeyString, uint32 defaultValue);
     void SetCyclesBetweenBuyOrSell();
+    void SetBuyingBotBuyCandidatesPerBuyCycle();
+    void GetConfigMinAndMax(std::string config, uint32& min, uint32& max);
     void AddCharacters(std::string characterGUIDString);
     void AddItemIDsFromString(std::set<uint32>& workingItemIDSet, std::string itemString, const char* parentOperationName);
     void AddToItemIDSet(std::set<uint32>& workingItemIDSet, uint32 itemID, const char* parentOperationName);

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -128,7 +128,8 @@ private:
 
     bool SellingBotEnabled;
     bool BuyingBotEnabled;
-    int CyclesBetweenBuyOrSell;
+    int CyclesBetweenBuyOrSellMin;
+    int CyclesBetweenBuyOrSellMax;
     uint32 MaxBuyoutPriceInCopper;
     float BuyoutVariationReducePercent;
     float BuyoutVariationAddPercent;
@@ -290,6 +291,7 @@ public:
     void InitializeConfiguration();
     uint32 GetRandomStackValue(std::string configKeyString, uint32 defaultValue);
     uint32 GetRandomStackIncrementValue(std::string configKeyString, uint32 defaultValue);
+    void SetCyclesBetweenBuyOrSell();
     void AddCharacters(std::string characterGUIDString);
     void AddItemIDsFromString(std::set<uint32>& workingItemIDSet, std::string itemString, const char* parentOperationName);
     void AddToItemIDSet(std::set<uint32>& workingItemIDSet, uint32 itemID, const char* parentOperationName);

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -129,6 +129,7 @@ private:
     bool SellingBotEnabled;
     bool BuyingBotEnabled;
     uint32 CyclesBetweenBuyOrSellMin;
+    uint32 CyclesBetweenBuyOrSell;
     uint32 CyclesBetweenBuyOrSellMax;
     uint32 MaxBuyoutPriceInCopper;
     float BuyoutVariationReducePercent;


### PR DESCRIPTION
## Changes Proposed:  
- Add potential for variance in:  
  - time between Buy/Sell cycles  
  - number of items considered for purchase during Buy/Sell cycle  
- Enable `AuctionHouseBot.Buyer.BuyCandidatesPerBuyCycle` and `AuctionHouseBot.AuctionHouseManagerCyclesBetweenBuyOrSell` to read either a single integer, or a pair of integers as values


## Reasoning:
I thought it might make the AH feel a bit more "player-like" if it were possible to configure variety in the frequency and number of items purchased by the Buyer Bot, rather than always buying a set number of items on a tight schedule.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds without errors
- Single integer config values still behave normally. Integer pairs entered in the expected format add variety to Buy/Sell cycle timing and # of items purchased as intended.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Set AuctionHouseBot.Buyer.BuyCandidatesPerBuyCycle to some pair of integers (1:5) -> Post several auctions -> AH should consider 1 to 5 items each time the Buy/Sell cycle hits.
2. Set AuctionHouseBot.AuctionHouseManagerCyclesBetweenBuyOrSell to some pair of integers (1:3) -> Add LOG_INFO statements, or use a timer to observe variance in time between Buy/Sell cycles.
  
Happy to make changes if needed!