### PR TITLE
Performance: Added batch processing to AddNewAuctions()

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -37,11 +37,8 @@
 #
 #    AuctionHouseBot.ItemsPerCycle
 #        How many items to post on the auction house every house update. Items
-#        in a cycle will be posted by a single randomly selected bot, so Keep
-#        this value low if you want highly diverse postings. Do note that
-#        this value has a direct impact on login startup time (specifically time
-#        from startup complete to first character being able to log in) so a 
-#        value greater than a few hundred is not recommended.
+#        in a cycle will be posted by a single randomly selected bot, so keep
+#        this value low if you want highly diverse "Seller" names in auction listings.
 #    Default 150
 #
 #    AuctionHouseBot.ListingExpireTimeInSecondsMin


### PR DESCRIPTION
## Changes Proposed:
- Utilize batch processing in AddNewAuctions() to improve start up time and reduce client-side "hanging" during DB transactions

## Reasoning:
Before, setting AuctionHouseBot.ItemsPerCycle to large values would take a very long time since each item to add would perform a full sql transaction round-trip (including overhead of logging, locking, and memory allocation). With a batched approach, we can reduce a lot of that overhead by appending many new items to the same transaction and taking advantage of its asynchronous nature.  
The risk with batch processing like this is that if any single item's transaction fails, the entire batch's commit is rolled back. I think with a relatively low batch size (default 500?), we can enjoy the benefits without sacrificing too much in case a rollback occurs. In any case, the batching has only been applied to items created by the AuctionHouseBot, so they don't have any real value to players, so its losses are unimportant. I think transactions that directly influence players should still be handled 1-at-a-time though.

## Performance:  
On my machine, I observed the following:  
- Without batching: ItemsPerCycle = `  2,000` -> ~23 sec to character select  
- With batching: ` ` ItemsPerCycle = `100,000` -> ~24 sec to character select 🤯   

With ItemsPerCycle = `100,000` I only noticed a 5% jump in my CPU utilization (YMMV). With more reasonable values (1,000 - 15,000) there was hardly a difference.

## Future Considerations:  
1. Should the Batch Size be exposed as a config value?
2. Maybe we could increase the default value of `ItemsPerCycle` ?
3. This could probably be followed up with some additional logic to "burst fill" an AuctionHouse that is empty or below some threshold % of MinItems. I think a lot of users would appreciate that after initially installing the module, or wiping the auctionhouse table after changing PriceMultipliers .

## Tests Performed:
- Builds without errors
- Set ItemsPerCycle = `200,000` and filled the AH to `1,000,000` items without any failed transactions

## How to Test the Changes:
1. Pull changes
2. Wipe auction house DB table
3. Set ItemsPerCycle and Min/MaxItems to something unreasonably high
4. Start the server and observe the time needed to reach character login screen. Auctions should be immediately available
