### PR TITLE
Improved AHBot diversity during buy/sell cycles

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -36,9 +36,8 @@
 #        AuctionHouseBot.GUIDs = 3,4 <- Both characters with GUID 3 and 4
 #
 #    AuctionHouseBot.ItemsPerCycle
-#        How many items to post on the auction house every house update. Items
-#        in a cycle will be posted by a single randomly selected bot, so keep
-#        this value low if you want highly diverse "Seller" names in auction listings.
+#        How many items to post on the auction house every house update.
+#        Items in a cycle will be posted by a randomly selected bot.
 #    Default 150
 #
 #    AuctionHouseBot.ListingExpireTimeInSecondsMin

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -307,8 +307,8 @@ public:
     ItemTemplate const* GetProducedItemFromRecipe(ItemTemplate const* recipeItemTemplate);
     void PopulateItemCandidatesAndProportions();
     uint32 GetRandomItemIDForListing();
-    void AddNewAuctions(Player* AHBplayer, FactionSpecificAuctionHouseConfig* config);
-    void AddNewAuctionBuyerBotBid(Player* AHBplayer, FactionSpecificAuctionHouseConfig* config);
+    void AddNewAuctions(std::vector<Player*> AHBPlayers, FactionSpecificAuctionHouseConfig* config);
+    void AddNewAuctionBuyerBotBid(std::vector<Player*> AHBPlayers, FactionSpecificAuctionHouseConfig* config);
     void PopulateVendorItemsPrices();
 
     template <typename ValueType>


### PR DESCRIPTION
## Changes Proposed:
- Rather than selecting 1 bot to handle all interactions during an Update() cycle, load all bots beforehand and have a random bot interact with each item to increase diversity in Seller listings and Buyer interactions

## Future Considerations:  
If merged, this PR and PR https://github.com/NathanHandley/mod-ah-bot/pull/27 "untie" `AuctionHouseBot.ItemsPerCycle` from performance limitations and reasons to keep a low value (previously this influenced Seller/Buyer diversity).  
Should the default value be raised considerably?

## Tests Performed:
- Builds without errors
- Tested buying and selling several items with multiple bot guids configured, and also with only 1 guid.
- Upon login after auctionhouse table wipe, new auctions have random bot listed as Seller, and Mail also lists random bots as Buyer