### PR TITLE
Added chat commands for GMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The AuctionHouseBot module adds the following in-game commands (for GMs only):
 | Command | Description |
 |----------|--------------|
 | `.ahbot reload` | Reloads the AuctionHouseBot configuration file and updates settings. |
-| `.ahbot empty` | Removes all auctions from all auction houses. Use with caution! |
+| `.ahbot empty` | Removes all AuctionHouseBot auctions from all auction houses.<br>Player auctions are unaffected. Bids on affected items are returned to players.<br>Use with caution! |
 | `.ahbot update` | Forces the bot to refresh or repopulate auction listings immediately.<br>Note: If you have multiple minutes configured between Buy/Sell cycles, you may have to run this additional times before you see results. |
 
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,18 @@ Notes:
 - Important!  By default, most player crafted items (except glyphs, bolts, maybe a few other things) are disabled from showing up in the auction house in order to encourage player crafting on lower pop servers.  If you want different behavior, alter the config variable "AuctionHouseBot.DisabledCraftedItemIDs" by deleting IDs you wish to show up.  Note that fish are also disabled to encourage fishing, and that's also managed by disabled lists.
 - It takes a few hours for the auction house to fully populate, as only 75 items gets added by default every 'tick'.  You can change this in the config with the AuctionHouseBot.ItemsPerCycle variable.
 - All price multpliers (along with the advanced pricing, see config) are applied multiplicative.  Example: A Category of 1.5x, Quality of 2x, and CategoryQuality of 1.4x would make the multiplier 4.2 (1.5 x 2 x 1.4).  The advanced pricing would then multiply that value further.  Using item level price multpliers, which create a multiplier of itemlevel x value, is also multiplicitive along with the others.  You cannot use item level price multipliers and advanced pricing, as advanced pricing will take priority between the two.
-- Bot-listed prices will not exceed 100k gold buyout
+- Bot-listed prices will not exceed 100k gold buyout  
+
+### In-Game Commands
+
+The AuctionHouseBot module adds the following in-game commands (for GMs only):
+
+| Command | Description |
+|----------|--------------|
+| `.ahbot reload` | Reloads the AuctionHouseBot configuration file and updates settings. |
+| `.ahbot empty` | Removes all auctions from all auction houses. Use with caution! |
+| `.ahbot update` | Forces the bot to refresh or repopulate auction listings immediately.<br>Note: If you have multiple minutes configured between Buy/Sell cycles, you may have to run this additional times before you see results. |
+
 
 ## Buying Bot Behavior
 

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -5,7 +5,7 @@
 #
 #    Available GM commands:
 #        .ahbot reload  - Reloads AuctionHouseBot configuration
-#        .ahbot empty   - Clears all auctions from all auction houses
+#        .ahbot empty   - Clears all AuctionHouseBot auctions from all auction houses
 #        .ahbot update  - Forces an immediate update cycle
 ###################################################################################################
 

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -1,5 +1,14 @@
 [worldserver]
 
+###################################################################################################
+# AUCTION HOUSE BOT IN-GAME COMMANDS
+#
+#    Available GM commands:
+#        .ahbot reload  - Reloads AuctionHouseBot configuration
+#        .ahbot empty   - Clears all auctions from all auction houses
+#        .ahbot update  - Forces an immediate update cycle
+###################################################################################################
+
 ###############################################################################
 # AUCTION HOUSE BOT SETTINGS
 #    AuctionHouseBot.DEBUG

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1636,38 +1636,7 @@ void AuctionHouseBot::EmptyAuctionHouses()
 
             // If auction has a bidder, refund that character
             if (ai.characterGUID != 0)
-            {
-                // Lookup accountID and accountName associated with bidder character
-                std::string accountIDQueryString =   "SELECT account  FROM characters WHERE guid = {}";
-                std::string accountNameQueryString = "SELECT username FROM account    WHERE id   = {}";
-
-                QueryResult accountIDQueryResult = CharacterDatabase.Query(accountIDQueryString, ai.characterGUID);
-                if (!accountIDQueryResult)
-                    continue;
-
-                uint32 bidderAccountID = (*accountIDQueryResult)[0].Get<uint32>();
-
-                QueryResult accountNameQueryResult = LoginDatabase.Query(accountNameQueryString, bidderAccountID);
-                if (!accountNameQueryResult)
-                    continue;
-
-                std::string bidderAccountName = (*accountNameQueryResult)[0].Get<std::string>();
-
-                // Load Player information, and issue refund
-                auto session = std::make_unique<WorldSession>(
-                    bidderAccountID, std::move(bidderAccountName), 0, nullptr,
-                    SEC_PLAYER, sWorld->getIntConfig(CONFIG_EXPANSION), 0, LOCALE_enUS, 0, false, false, 0
-                );
-
-                auto player = std::make_unique<Player>(session.get());
-                if (!player)
-                    continue;
-
-                player->Initialize(ai.characterGUID);
-
                 sAuctionMgr->SendAuctionCancelledToBidderMail(auction,  trans);
-                player->ModifyMoney(-int32(auction->GetAuctionCut())); // ModifyMoney() already handles negative check
-            }
 
             // Remove item from AH
             auction->DeleteFromDB(trans);

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -298,6 +298,7 @@ public:
 
     void Update();
     void InitializeConfiguration();
+    void EmptyAuctionHouses();
     uint32 GetRandomStackValue(std::string configKeyString, uint32 defaultValue);
     uint32 GetRandomStackIncrementValue(std::string configKeyString, uint32 defaultValue);
     void SetCyclesBetweenBuyOrSell();

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -2,6 +2,7 @@
  * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
 */
 
+#include "Chat.h"
 #include "ScriptMgr.h"
 #include "AuctionHouseBot.h"
 #include "Log.h"
@@ -118,9 +119,59 @@ public:
     }
 };
 
+class AHBot_CommandScript : public CommandScript
+{
+public:
+    AHBot_CommandScript() : CommandScript("AHBot_CommandScript") { }
+
+    Acore::ChatCommands::ChatCommandTable GetCommands() const override
+    {
+        static Acore::ChatCommands::ChatCommandTable AHBotCommandTable = {
+            {"update", HandleAHBotUpdateCommand, SEC_GAMEMASTER, Acore::ChatCommands::Console::Yes},
+            {"reload", HandleAHBotReloadCommand, SEC_GAMEMASTER, Acore::ChatCommands::Console::Yes},
+            {"empty",  HandleAHBotEmptyCommand,  SEC_GAMEMASTER, Acore::ChatCommands::Console::Yes}
+        };
+
+        static Acore::ChatCommands::ChatCommandTable commandTable = {
+            {"ahbot", AHBotCommandTable},
+        };
+
+        return commandTable;
+    }
+
+    static bool HandleAHBotUpdateCommand(ChatHandler* handler, const char* /*args*/)
+    {
+        LOG_INFO("module", "AuctionHouseBot: Updating Auction House...");
+        handler->PSendSysMessage("AuctionHouseBot: Updating Auction House...");
+        AuctionHouseBot::instance()->Update();
+        return true;
+    }
+
+    static bool HandleAHBotReloadCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        LOG_INFO("module", "AuctionHouseBot: Reloading Config...");
+        handler->PSendSysMessage("AuctionHouseBot: Reloading Config...");
+
+        // Reload config file with isReload = true
+        sConfigMgr->LoadModulesConfigs(true, false);
+        AuctionHouseBot::instance()->InitializeConfiguration();
+        AuctionHouseBot::instance()->PopulateItemCandidatesAndProportions();
+        return true;
+    }
+
+    static bool HandleAHBotEmptyCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        LOG_INFO("module", "AuctionHouseBot: Emptying Auction House...");
+        handler->PSendSysMessage("AuctionHouseBot: Emptying Auction House...");
+        AuctionHouseBot::instance()->EmptyAuctionHouses();
+        return true;
+    }
+};
+
 void AddAHBotScripts()
 {
     new AHBot_WorldScript();
     new AHBot_AuctionHouseScript();
     new AHBot_MailScript();
+    new AHBot_CommandScript();
 }

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -129,7 +129,8 @@ public:
         static Acore::ChatCommands::ChatCommandTable AHBotCommandTable = {
             {"update", HandleAHBotUpdateCommand, SEC_GAMEMASTER, Acore::ChatCommands::Console::Yes},
             {"reload", HandleAHBotReloadCommand, SEC_GAMEMASTER, Acore::ChatCommands::Console::Yes},
-            {"empty",  HandleAHBotEmptyCommand,  SEC_GAMEMASTER, Acore::ChatCommands::Console::Yes}
+            {"empty",  HandleAHBotEmptyCommand,  SEC_GAMEMASTER, Acore::ChatCommands::Console::Yes},
+            {"help",  HandleAHBotHelpCommand,  SEC_GAMEMASTER, Acore::ChatCommands::Console::Yes}
         };
 
         static Acore::ChatCommands::ChatCommandTable commandTable = {
@@ -164,6 +165,15 @@ public:
         LOG_INFO("module", "AuctionHouseBot: Emptying Auction House...");
         handler->PSendSysMessage("AuctionHouseBot: Emptying Auction House...");
         AuctionHouseBot::instance()->EmptyAuctionHouses();
+        return true;
+    }
+
+    static bool HandleAHBotHelpCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        handler->PSendSysMessage("AuctionHouseBot commands:");
+        handler->PSendSysMessage("  .ahbot reload - Reloads configuration");
+        handler->PSendSysMessage("  .ahbot empty  - Removes all auctions");
+        handler->PSendSysMessage("  .ahbot update - Runs an update cycle");
         return true;
     }
 };

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -172,7 +172,7 @@ public:
     {
         handler->PSendSysMessage("AuctionHouseBot commands:");
         handler->PSendSysMessage("  .ahbot reload - Reloads configuration");
-        handler->PSendSysMessage("  .ahbot empty  - Removes all auctions");
+        handler->PSendSysMessage("  .ahbot empty  - Removes all AuctionHouseBot auctions");
         handler->PSendSysMessage("  .ahbot update - Runs an update cycle");
         return true;
     }


### PR DESCRIPTION
### Changes Proposed:
- Add the following chat commands for GM accounts
  - `.ahbot update` - forces a cycle of the `Update()` logic
  - `.ahbot reload` - reloads the config file so changes can be made without the need to restart the server
  - `.ahbot empty` - removes all auctions from all auction houses
  - `.ahbot help` - prints descriptions of the above commands

### Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds without errors
- Tested in-game as a GM - all behaving as expected
- Tested in-game as a normal player - commands yield `Command <command> does not exist`
- Made macros for each command and set them on the hotbar, then mashed all 3 buttons for a few seconds without issue

### How to Test the Changes:
1. Create a gm account `.account create $account $password` , `.account set gmlevel [$account] 3 -1`
2. Login to gm account
3. Check auction house for initial item count
4. `.ahbot empty`, observe auction house is now empty
5. `.ahbot update`, observe auction house now has items, per your config settings
6. Without restarting the server, modify your config settings (ItemsPerCycle, EnableSeller, PriceMultipliers, etc)
7. `.ahbot reload` -> `.ahbot update`, observe changes from new config settings
