### PR TITLE
Feature: Use DB drop rates to determine rare/epic weapons/armor/recipes likeliness in AH

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -46,6 +46,11 @@
 #        acore_characters.item_instance database table to grow over time.
 #    Default: false (disabled)
 #
+#    AuctionHouseBot.Seller.UseDBDropRates.Enabled
+#        Enable/Disable the Seller using items' in-game drop rates from enemies 
+#        and gameobjects to determine probability of listing the items on the AH.
+#    Default: false (disabled)
+#
 #    AuctionHouseBot.GUIDs
 #        These are the character GUIDS (from characters->characters table) that
 #        will be used to create auctions and otherwise interact with auctions.
@@ -76,6 +81,7 @@ AuctionHouseBot.MinutesBetweenBuyCycle = 1
 AuctionHouseBot.MinutesBetweenSellCycle = 1
 AuctionHouseBot.EnableSeller = false
 AuctionHouseBot.ReturnExpiredAuctionItemsToBot = false
+AuctionHouseBot.Seller.UseDBDropRates.Enabled = false
 AuctionHouseBot.GUIDs = 0
 AuctionHouseBot.ItemsPerCycle = 150
 AuctionHouseBot.ListingExpireTimeInSecondsMin = 900

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -46,11 +46,6 @@
 #        acore_characters.item_instance database table to grow over time.
 #    Default: false (disabled)
 #
-#    AuctionHouseBot.Seller.UseDBDropRates.Enabled
-#        Enable/Disable the Seller using items' in-game drop rates from enemies 
-#        and gameobjects to determine probability of listing the items on the AH.
-#    Default: false (disabled)
-#
 #    AuctionHouseBot.GUIDs
 #        These are the character GUIDS (from characters->characters table) that
 #        will be used to create auctions and otherwise interact with auctions.
@@ -81,11 +76,41 @@ AuctionHouseBot.MinutesBetweenBuyCycle = 1
 AuctionHouseBot.MinutesBetweenSellCycle = 1
 AuctionHouseBot.EnableSeller = false
 AuctionHouseBot.ReturnExpiredAuctionItemsToBot = false
-AuctionHouseBot.Seller.UseDBDropRates.Enabled = false
 AuctionHouseBot.GUIDs = 0
 AuctionHouseBot.ItemsPerCycle = 150
 AuctionHouseBot.ListingExpireTimeInSecondsMin = 900
 AuctionHouseBot.ListingExpireTimeInSecondsMax = 86400
+
+###############################################################################
+#    AuctionHouseBot.AdvancedListingRules.UseDropRates.Enabled
+#        Enable/Disable the Seller using items' in-game drop rates from Enemies
+#        and GameObjects to determine the probability of listing them on the AH.
+#        Attempts to simulate "live" AHs by making very powerful items appear less often.
+#        This setting respects ListProportion config. It can also result in more duplicate
+#        items appearing on the AH due to higher-drop-rate items being selected more often.
+#        Crafted items may also appear more often since their drop rate is effectively 100%.
+#    Default: false (disabled)
+#
+#    AuctionHouseBot.AdvancedListingRules.UseDropRates.MinQuality
+#        The minimum quality that should be included by AdvancedListingRules.UseDropRates.
+#        Value should be the integer corresponding to the desired minimum rarity.
+#        Examples: Setting to 3 will apply to Rare, Epic, Legendary, and Heirloom.
+#          Setting to 1 will apply to Common, Uncommon, Rare, Epic, Legendary, and Heirloom.
+#        (0) Poor, (1) Common, (2) Uncommon, (3) Rare, (4) Epic, (5) Legendary, (6) Heirloom
+#    Default: 3
+#
+#    AuctionHouseBot.Seller.AdvancedListingRules.UseDropRates.<Category>
+#        Toggle AdvancedListingRules.UseDropRates behavior for individual category.
+#        Only applied if AdvancedListingRules.UseDropRates.Enabled is true.
+#    Default: true (enabled)
+###############################################################################
+
+AuctionHouseBot.AdvancedListingRules.UseDropRates.Enabled = false
+AuctionHouseBot.AdvancedListingRules.UseDropRates.MinQuality = 2
+
+AuctionHouseBot.AdvancedListingRules.UseDropRates.Weapon = true
+AuctionHouseBot.AdvancedListingRules.UseDropRates.Armor  = true
+AuctionHouseBot.AdvancedListingRules.UseDropRates.Recipe = true
 
 ###############################################################################
 #    AuctionHouseBot.MaxBuyoutPriceInCopper

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -25,7 +25,6 @@
 #include "Config.h"
 #include "Player.h"
 #include "WorldSession.h"
-#include "GameTime.h"
 #include "DatabaseEnv.h"
 #include "ItemTemplate.h"
 #include "SharedDefines.h"
@@ -33,6 +32,7 @@
 #include <cmath>
 
 #include <set>
+#include <unordered_map>
 
 using namespace std;
 
@@ -157,6 +157,7 @@ AuctionHouseBot::AuctionHouseBot() :
     ListedItemIDRestrictedEnabled(false),
     ListedItemIDMin(0),
     ListedItemIDMax(200000),
+    SellerUseDBDropRates(false),
     LastBuyCycleCount(0),
     LastSellCycleCount(0),
     ActiveListMultipleItemID(0),
@@ -971,6 +972,7 @@ void AuctionHouseBot::AddNewAuctions(std::vector<Player*> AHBPlayers, FactionSpe
     for (uint32 cnt = 1; cnt <= newItemsToListCount; cnt++)
     {
         auto trans = CharacterDatabase.BeginTransaction();
+        ItemTemplate const* prototype = nullptr;
         uint32 batchCount = 0;
 
         while (batchCount < 500 && itemsGenerated < newItemsToListCount)
@@ -980,6 +982,15 @@ void AuctionHouseBot::AddNewAuctions(std::vector<Player*> AHBPlayers, FactionSpe
             if (ActiveListMultipleItemID != 0)
             {
                 itemID = ActiveListMultipleItemID;
+
+                prototype = sObjectMgr->GetItemTemplate(itemID);
+                if (!prototype)
+                {
+                    if (debug_Out)
+                        LOG_ERROR("module", "AHSeller: prototype == NULL");
+                    continue;
+                }
+
                 RemainingListMultipleCount--;
                 if (RemainingListMultipleCount <= 0)
                     ActiveListMultipleItemID = 0;
@@ -987,7 +998,59 @@ void AuctionHouseBot::AddNewAuctions(std::vector<Player*> AHBPlayers, FactionSpe
             else
             {
                 itemID = GetRandomItemIDForListing();
-                if (itemID != 0 && ItemListProportionMultipliedItemIDs.find(itemID) != ItemListProportionMultipliedItemIDs.end() &&
+                if (itemID == 0)
+                {
+                    if (debug_Out)
+                        LOG_ERROR("module", "AHSeller: Item::CreateItem() failed as the ItemID is 0");
+                    continue;
+                }
+
+                prototype = sObjectMgr->GetItemTemplate(itemID);
+                if (!prototype)
+                {
+                    if (debug_Out)
+                        LOG_ERROR("module", "AHSeller: prototype == NULL");
+                    continue;
+                }
+
+                // If current item is crafted, ineligible, or quest reward, ignore drop rates and continue to list it
+                if (SellerUseDBDropRates &&
+                    IsItemEligibleForDBDropRates(prototype) &&
+                    !IsItemCrafted(itemID) &&
+                    !IsItemQuestReward(itemID))
+                {
+                    // The AHBot has chosen a rare/epic armor/weapon/recipe, so select another item
+                    //   of that type based on drop rates. This way ListProportions are respected.
+
+                    // Roll for rarity tier
+                    double r = 100.0 * (urand(0, INT32_MAX) / static_cast<double>(INT32_MAX));
+                    int tier = GetItemDropChanceTier(r);
+
+                    // If chosen tier is empty, search rarer tiers until not empty
+                    auto& tierBuckets = ItemTiersByClassAndQuality[prototype->Class][prototype->Quality];
+                    while (tierBuckets[tier].empty() && tier < 10) {
+                        if (debug_Out)
+                            LOG_INFO("module", "Bucket is empty for class {} quality {} tier {}", prototype->Class, prototype->Quality, tier);
+                        tier++;
+                    }
+
+                    // Pull a random item from selected rarity tier
+                    auto& bucket = tierBuckets[tier];
+                    if (!bucket.empty())
+                    {
+                        itemID = bucket[rand() % bucket.size()];
+                        prototype = sObjectMgr->GetItemTemplate(itemID);
+                        if (!prototype)
+                        {
+                            if (debug_Out)
+                                LOG_ERROR("module", "AHSeller: prototype == NULL");
+                            continue;
+                        }
+                    }
+                    else continue;
+                }
+
+                if (ItemListProportionMultipliedItemIDs.find(itemID) != ItemListProportionMultipliedItemIDs.end() &&
                     ItemListProportionMultipliedItemIDs[itemID] > 1)
                 {
                     ActiveListMultipleItemID = itemID;
@@ -995,22 +1058,6 @@ void AuctionHouseBot::AddNewAuctions(std::vector<Player*> AHBPlayers, FactionSpe
                     if (debug_Out)
                         LOG_INFO("module", "AHSeller: Is listing item ID {} which is configured for {} multiples from ListMultipliedItemIDs", itemID, ItemListProportionMultipliedItemIDs[itemID]);
                 }
-            }
-
-            // Prevent invalid IDs
-            if (itemID == 0)
-            {
-                if (debug_Out)
-                    LOG_ERROR("module", "AHSeller: Item::CreateItem() failed as the ItemID is 0");
-                continue;
-            }
-
-            ItemTemplate const* prototype = sObjectMgr->GetItemTemplate(itemID);
-            if (prototype == NULL)
-            {
-                if (debug_Out)
-                    LOG_ERROR("module", "AHSeller: prototype == NULL");
-                continue;
             }
 
             Player* AHBplayer = AHBPlayers[urand(0, AHBPlayers.size() - 1)];
@@ -1068,6 +1115,272 @@ void AuctionHouseBot::AddNewAuctions(std::vector<Player*> AHBPlayers, FactionSpe
     }
     if (debug_Out)
         LOG_INFO("module", "AHSeller: Added {} items", itemsGenerated);
+}
+
+void AuctionHouseBot::PopulateItemDropChances()
+{
+    // Search creature loot templates, referenced loot_loot_template, group_loot tables, and object_loot tables for items' drop rates
+    std::string directDropString = R"SQL(
+        SELECT it.entry AS itemID, 
+                clt.Chance AS direct_chance, 
+                0 AS reference_chance
+            FROM creature_template ct
+            JOIN creature_loot_template clt ON clt.Entry = ct.lootid
+            JOIN item_template it ON it.entry = clt.Item
+            WHERE clt.Reference = 0 AND clt.GroupId = 0 AND it.class IN (2,4,9) AND it.quality > 2
+    )SQL";
+
+    std::string referenceDropString = R"SQL(
+        WITH reference_group_counts AS (
+            SELECT entry AS referenceID, COUNT(*) AS groupCount
+            FROM reference_loot_template
+            GROUP BY entry
+        ),
+        all_references AS (
+            SELECT 
+                rlt.Entry AS referenceID,
+                rlt.Item AS itemID,
+                rlt.Chance AS referenceChance,
+                rgc.groupCount,
+                MIN(clt.Chance) AS creatureChance,
+                CASE WHEN COUNT(clt.Entry) > 0 THEN 1 ELSE 0 END AS hasCreature
+            FROM reference_loot_template rlt
+            JOIN reference_group_counts rgc ON rlt.Entry = rgc.referenceID
+            LEFT JOIN creature_loot_template clt ON clt.Reference = rlt.Entry
+            WHERE clt.`Comment` NOT LIKE '%Placeholder%'
+            GROUP BY rlt.Entry, rlt.Item, rlt.Chance, rgc.groupCount
+        )
+        SELECT 
+            ar.itemID	AS itemID,
+            0           AS direct_chance, 
+            CASE
+                WHEN ar.hasCreature = 1
+                    THEN (1.0 / case when ar.groupCount < 6 then 6 ELSE ar.groupCount end) *
+                        COALESCE(NULLIF(ar.referenceChance,0),1) *
+                        COALESCE(NULLIF(ar.creatureChance,0),1)
+                ELSE
+                    (1.0 / ar.groupCount) *
+                    COALESCE(NULLIF(ar.referenceChance,0),1)
+            END AS reference_chance
+        FROM all_references ar
+        JOIN item_template it ON it.entry = ar.itemID
+        WHERE it.class IN (2,4,9) AND it.quality > 2
+    )SQL";
+
+    // This will lookup items in referenced_loot_template whose Reference entry is not associated with a creature_loot_template
+    std::string danglingReferenceDropString = R"SQL(
+        WITH reference_group_counts AS (
+            SELECT entry AS referenceID, COUNT(*) AS groupCount
+            FROM reference_loot_template
+            GROUP BY entry
+        ),
+        creature_references AS (
+            SELECT DISTINCT Reference AS referenceID FROM creature_loot_template WHERE REFERENCE != 0
+        ),
+        reference_data AS (
+            SELECT 
+                rlt.Entry AS referenceID,
+                rlt.Item AS itemID,
+                rlt.Chance AS referenceChance,
+                rgc.groupCount
+            FROM reference_loot_template rlt
+            JOIN reference_group_counts rgc ON rlt.Entry = rgc.referenceID
+        )
+        SELECT 
+                rd.itemID AS itemID,
+                0         AS direct_chance,
+                (1.0 / rd.groupCount) * COALESCE(NULLIF(rd.referenceChance, 0), 1) AS reference_chance
+            FROM reference_data rd
+            JOIN item_template it ON it.entry = rd.itemID
+            WHERE it.class IN (2, 4, 9)
+            AND it.quality > 2        
+    )SQL";
+
+    std::string groupDropString = R"SQL(
+        WITH group_tables AS (
+            SELECT clt.Entry AS loot_entry, clt.GroupId AS group_id, clt.Chance AS chance, clt.Item AS item_id, it.`name` AS itemName, it.class AS itemClass, it.Quality AS itemQuality
+            FROM creature_loot_template clt
+            JOIN item_template it ON clt.Item = it.entry
+            WHERE clt.groupid != 0 AND clt.REFERENCE = 0
+        )
+        SELECT item_id, 
+                0 AS direct_chance, 
+                CASE 
+                    WHEN chance = 0 THEN (1.0 / item_count) * (1 - POWER(1 - (1.0 / item_count), item_count)) * 100
+                    WHEN chance != 0 THEN ((1.0 / item_count) * (1 - POWER(1 - (1.0 / item_count), item_count)) * 100) * chance/100
+                END AS reference_chance
+            FROM (
+                SELECT group_tables.*, COUNT(*) OVER (PARTITION BY loot_entry, group_id) AS item_count
+                FROM group_tables
+            ) compute_item_count
+            WHERE itemClass IN (2,4,9) AND itemQuality > 2
+    )SQL";
+
+    std::string objectsDropString = R"SQL(
+        SELECT it.entry    AS itemID,
+               ilt.Chance  AS direct_chance,
+               0		   AS reference_chance
+            FROM item_loot_template ilt
+            JOIN item_template it ON it.entry = ilt.Item
+            WHERE it.class IN (2,4,9) AND it.quality > 2 AND chance != 0
+        UNION ALL 
+        SELECT it.entry    AS itemID,
+               golt.Chance AS direct_chance,
+               0				 AS reference_chance
+            FROM gameobject_loot_template golt
+            JOIN item_template it ON it.entry = golt.Item
+            WHERE it.class IN (2,4,9) AND it.quality > 2 AND chance != 0
+    )SQL";
+
+    QueryResult directResult = WorldDatabase.Query(directDropString);
+    QueryResult referenceResult = WorldDatabase.Query(referenceDropString);
+    QueryResult danglingReferenceResult = WorldDatabase.Query(danglingReferenceDropString);
+    QueryResult groupResult = WorldDatabase.Query(groupDropString);
+    QueryResult objectsDropResult = WorldDatabase.Query(objectsDropString);
+    if (!directResult || !referenceResult || !danglingReferenceResult || !groupResult || !objectsDropResult)
+    {
+        LOG_ERROR("module", "AuctionHouseBot: PopulateItemDropChances() failed!");
+        return;
+    }
+
+    // Add drop rate of all results to CachedItemDropRates 
+    auto parseResults = [this](QueryResult result) 
+    {
+        do {
+            Field* fields = result->Fetch();
+            double directDropChance = 0.0;
+            double referenceDropChance = 0.0;
+            uint32 itemID = fields[0].Get<uint32>();
+
+            // Ignore quest rewards and crafted items, they have "100%" drop rate
+            if (IsItemQuestReward(itemID) || IsItemCrafted(itemID))
+                continue;
+
+            if (!fields[1].IsNull())
+                directDropChance = fields[1].Get<double>(); 
+            if (!fields[2].IsNull())
+                referenceDropChance = fields[2].Get<double>();
+            
+            double higherDropChance = (directDropChance > referenceDropChance) ? directDropChance : referenceDropChance;
+
+            if (CachedItemDropRates[itemID] < higherDropChance) 
+                CachedItemDropRates[itemID] = higherDropChance;
+
+        } while (result->NextRow());
+    };
+
+    parseResults(directResult);
+    parseResults(referenceResult);
+    parseResults(danglingReferenceResult);
+    parseResults(groupResult);
+    parseResults(objectsDropResult);
+
+    // Process item candidates: filter invalid entries and group by drop rate tier
+    for (auto& [classID, qualityGroups] : ItemCandidatesByItemClassAndQuality)
+    {
+        for (auto& [qualityID, candidates] : qualityGroups)
+        {
+            // Erase items that are not crafted, not quest rewards, and missing DB drop rate
+            candidates.erase(
+                std::remove_if(
+                    candidates.begin(),
+                    candidates.end(),
+                    [&](uint32 id)
+                    {
+                        ItemTemplate const* proto = sObjectMgr->GetItemTemplate(id);
+                        if (!IsItemEligibleForDBDropRates(proto))
+                            return false;
+
+                        bool shouldErase = !IsItemCrafted(id)
+                                        && !IsItemQuestReward(id)
+                                        && !CachedItemDropRates.contains(id);
+
+                        return shouldErase;
+                    }),
+                candidates.end()
+            );
+
+            // Now process the remaining valid items
+            for (uint32 id : candidates)
+            {
+                ItemTemplate const* proto = sObjectMgr->GetItemTemplate(id);
+                if (!IsItemEligibleForDBDropRates(proto))
+                    continue;
+
+                double rate = CachedItemDropRates[id];
+                int tier = GetItemDropChanceTier(rate);
+                ItemTiersByClassAndQuality[proto->Class][proto->Quality][tier].push_back(id);
+            }
+        }
+    }
+
+    if (debug_Out)
+    {
+        // Show number of items in each tier
+        for (int i = 0; i < 17; i++)
+            for (int j = 0; j < 7; j++)
+                for (int k = 0; k < 10; k++)
+                {
+                    if (i == 2)
+                        LOG_INFO("module", "Armor Count: Rarity {} Tier {} has {} items", j, k, ItemTiersByClassAndQuality[i][j][k].size());
+                    if (i == 4)
+                        LOG_INFO("module", "Weapon Count: Rarity {} Tier {} has {} items", j, k, ItemTiersByClassAndQuality[i][j][k].size());
+                    if (i == 9)
+                        LOG_INFO("module", "Recipe Count: Rarity {} Tier {} has {} items", j, k, ItemTiersByClassAndQuality[i][j][k].size());
+                }
+    }
+}
+
+void AuctionHouseBot::PopulateQuestRewardItemIDs()
+{
+    string questRewardsString = R"SQL(
+        SELECT DISTINCT item_id
+            FROM (
+                SELECT RewardItem1 AS item_id FROM quest_template UNION ALL
+                SELECT RewardItem2 AS item_id FROM quest_template UNION ALL
+                SELECT RewardItem3 AS item_id FROM quest_template UNION ALL
+                SELECT RewardItem4 AS item_id FROM quest_template UNION ALL
+                SELECT ItemDrop1 AS item_id FROM quest_template UNION ALL
+                SELECT ItemDrop2 AS item_id FROM quest_template UNION ALL
+                SELECT ItemDrop3 AS item_id FROM quest_template UNION ALL
+                SELECT ItemDrop4 AS item_id FROM quest_template UNION ALL
+                SELECT RewardChoiceItemID1 AS item_id FROM quest_template UNION ALL
+                SELECT RewardChoiceItemID2 AS item_id FROM quest_template UNION ALL
+                SELECT RewardChoiceItemID3 AS item_id FROM quest_template UNION ALL
+                SELECT RewardChoiceItemID4 AS item_id FROM quest_template UNION ALL
+                SELECT RewardChoiceItemID5 AS item_id FROM quest_template UNION ALL
+                SELECT RewardChoiceItemID6 AS item_id FROM quest_template
+            ) AS quest_rewards
+            WHERE item_id != 0
+    )SQL";
+
+    QueryResult questRewardsResult = WorldDatabase.Query(questRewardsString);
+    if (!questRewardsResult)
+    {
+        LOG_ERROR("module", "AuctionHouseBot: Quest Rewards lookup failed.");
+        return;
+    }
+
+    do 
+    {
+        uint32 id = questRewardsResult->Fetch()->Get<uint32>();
+        QuestRewardItemIDs.insert(id);
+    } while (questRewardsResult->NextRow());
+}
+
+int AuctionHouseBot::GetItemDropChanceTier(double dropRate)
+{
+    if (dropRate > 10)        return 0;
+    else if (dropRate > 5)    return 1;
+    else if (dropRate > 2)    return 2;
+    else if (dropRate > 1)    return 3;
+    else if (dropRate > 0.5)  return 4;
+    else if (dropRate > 0.2)  return 5;
+    else if (dropRate > 0.1)  return 6;
+    else if (dropRate > 0.05) return 7;
+    else if (dropRate > 0.02) return 8;
+    else if (dropRate > 0.01) return 9;
+    else return 10;
 }
 
 void AuctionHouseBot::AddNewAuctionBuyerBotBid(std::vector<Player*> AHBPlayers, FactionSpecificAuctionHouseConfig *config)
@@ -1375,6 +1688,7 @@ void AuctionHouseBot::InitializeConfiguration()
     SetCyclesBetweenBuyOrSell();
     ReturnExpiredAuctionItemsToBot = sConfigMgr->GetOption<bool>("AuctionHouseBot.ReturnExpiredAuctionItemsToBot", false);
     ItemsPerCycle = sConfigMgr->GetOption<uint32>("AuctionHouseBot.ItemsPerCycle", 75);
+    SellerUseDBDropRates = sConfigMgr->GetOption<bool>("AuctionHouseBot.Seller.UseDBDropRates.Enabled", false);
     MaxBuyoutPriceInCopper = sConfigMgr->GetOption<uint32>("AuctionHouseBot.MaxBuyoutPriceInCopper", 1000000000);
     BuyoutVariationReducePercent = sConfigMgr->GetOption<float>("AuctionHouseBot.BuyoutVariationReducePercent", 0.15f);
     BuyoutVariationAddPercent = sConfigMgr->GetOption<float>("AuctionHouseBot.BuyoutVariationAddPercent", 0.25f);
@@ -1983,4 +2297,22 @@ void AuctionHouseBot::CleanupExpiredAuctionItems()
     } while (queryItemInstancesResult->NextRow());
 
     CharacterDatabase.CommitTransaction(trans);
+}
+
+bool AuctionHouseBot::IsItemQuestReward(uint32 itemID)
+{
+    return (QuestRewardItemIDs.find(itemID) != QuestRewardItemIDs.end());
+}
+
+bool AuctionHouseBot::IsItemCrafted(uint32 itemID)
+{
+    return (ItemIDsProducedByRecipes.find(itemID) != ItemIDsProducedByRecipes.end());
+}
+
+bool AuctionHouseBot::IsItemEligibleForDBDropRates(ItemTemplate const* proto)
+{
+    return (proto->Quality >= ITEM_QUALITY_RARE && 
+           (proto->Class == ITEM_CLASS_WEAPON ||
+            proto->Class == ITEM_CLASS_ARMOR  ||
+            proto->Class == ITEM_CLASS_RECIPE));
 }

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -278,6 +278,10 @@ private:
     uint32 ListedItemIDMax;
     std::set<uint32> ListedItemIDExceptionItems;
     bool PreventOverpayingForVendorItems;
+    std::unordered_map<uint32, double> CachedItemDropRates;
+    std::vector<uint32> ItemTiersByClassAndQuality[17][7][11]; // [Classes][Qualities][Tiers]
+    bool SellerUseDBDropRates;
+    std::unordered_set<uint32> QuestRewardItemIDs;
 
     FactionSpecificAuctionHouseConfig AllianceConfig;
     FactionSpecificAuctionHouseConfig HordeConfig;
@@ -314,6 +318,12 @@ public:
     const char* GetCategoryName(ItemClass category);
     uint32 GetStackSizeForItem(ItemTemplate const* itemProto) const;
     void CalculateItemValue(ItemTemplate const* itemProto, uint64& outBidPrice, uint64& outBuyoutPrice);
+    void PopulateItemDropChances();
+    void PopulateQuestRewardItemIDs();
+    bool IsItemQuestReward(uint32 itemID);
+    bool IsItemCrafted(uint32 itemID);
+    bool IsItemEligibleForDBDropRates(ItemTemplate const* proto);
+    int GetItemDropChanceTier(double dropRate);
     float GetAdvancedPricingMultiplier(ItemTemplate const* itemProto);
     ItemTemplate const* GetProducedItemFromRecipe(ItemTemplate const* recipeItemTemplate);
     std::unordered_set<uint32> GetItemIDsProducedByRecipes();

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -280,7 +280,11 @@ private:
     bool PreventOverpayingForVendorItems;
     std::unordered_map<uint32, double> CachedItemDropRates;
     std::vector<uint32> ItemTiersByClassAndQuality[17][7][11]; // [Classes][Qualities][Tiers]
-    bool SellerUseDBDropRates;
+    bool AdvancedListingRuleUseDropRatesEnabled;
+    bool AdvancedListingRuleUseDropRatesWeaponEnabled;
+    bool AdvancedListingRuleUseDropRatesArmorEnabled;
+    bool AdvancedListingRuleUseDropRatesRecipeEnabled;
+    int AdvancedListingRuleUseDropRatesMinQuality;
     std::unordered_set<uint32> QuestRewardItemIDs;
 
     FactionSpecificAuctionHouseConfig AllianceConfig;
@@ -319,6 +323,7 @@ public:
     uint32 GetStackSizeForItem(ItemTemplate const* itemProto) const;
     void CalculateItemValue(ItemTemplate const* itemProto, uint64& outBidPrice, uint64& outBuyoutPrice);
     void PopulateItemDropChances();
+    std::string GetAdvancedListingRuleUseDropRatesEnabledCategoriesString();
     void PopulateQuestRewardItemIDs();
     bool IsItemQuestReward(uint32 itemID);
     bool IsItemCrafted(uint32 itemID);

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -26,7 +26,7 @@ public:
             LOG_INFO("server.loading", "AuctionHouseBot: (Re)populating item candidate lists ...");
             auctionbot->PopulateItemCandidatesAndProportions();
 
-            if (sConfigMgr->GetOption<bool>("AuctionHouseBot.Seller.UseDBDropRates.Enabled", true))
+            if (sConfigMgr->GetOption<bool>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Enabled", true))
             {
                 auctionbot->PopulateQuestRewardItemIDs();
                 auctionbot->PopulateItemDropChances();
@@ -38,7 +38,7 @@ public:
     {
         LOG_INFO("server.loading", "AuctionHouseBot: (Re)populating item candidate lists ...");
         auctionbot->PopulateItemCandidatesAndProportions();
-        if (sConfigMgr->GetOption<bool>("AuctionHouseBot.Seller.UseDBDropRates.Enabled", true))
+        if (sConfigMgr->GetOption<bool>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Enabled", true))
         {
             auctionbot->PopulateQuestRewardItemIDs();
             auctionbot->PopulateItemDropChances();

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -24,7 +24,6 @@ public:
         if (HasPerformedStartup == true)
         {
             LOG_INFO("server.loading", "AuctionHouseBot: (Re)populating item candidate lists ...");
-            auctionbot->PopulateItemCandidatesAndProportions();
         }
     }
 
@@ -32,6 +31,11 @@ public:
     {
         LOG_INFO("server.loading", "AuctionHouseBot: (Re)populating item candidate lists ...");
         auctionbot->PopulateItemCandidatesAndProportions();
+        if (sConfigMgr->GetOption<bool>("AuctionHouseBot.Seller.UseDBDropRates.Enabled", true))
+        {
+            auctionbot->PopulateQuestRewardItemIDs();
+            auctionbot->PopulateItemDropChances();
+        }
         HasPerformedStartup = true;
     }
 };

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -24,6 +24,13 @@ public:
         if (HasPerformedStartup == true)
         {
             LOG_INFO("server.loading", "AuctionHouseBot: (Re)populating item candidate lists ...");
+            auctionbot->PopulateItemCandidatesAndProportions();
+
+            if (sConfigMgr->GetOption<bool>("AuctionHouseBot.Seller.UseDBDropRates.Enabled", true))
+            {
+                auctionbot->PopulateQuestRewardItemIDs();
+                auctionbot->PopulateItemDropChances();
+            }
         }
     }
 


### PR DESCRIPTION
### Changes Proposed:
- Add feature toggle to enable AHBot to list [ Rare / Epic ] [ Weapons / Armor / Recipes ] based on the item's in-game drop chances. This _should_ make the AH resemble live economies a bit more by posting rare items according to simulated drop chances.

### Feature logic:  
The gist of the methodology is:  
1. **Cache relevant item data** – Lookup and cache drop rates for items that are direct or indirect drops (from creatures, reference_loot_template, or loot groups), and also quest reward items.  
2. **Filter invalid candidates** – Remove items from `ItemCandidatesByItemClassAndQuality` that are not crafted, not quest rewards, and have no cached drop rate.  
3. **Assign items to tier buckets** – Group eligible items into “tier rarity” buckets based on Class, Quality, and cached drop rate.  
4. **Select items during auction creation** – During AddNewAuctions(), an initial itemID is selected according to ListProportion config. The Class and Quality of this item determine which subset of items are eligible (to ensure ListProportion is still respected).  A random number is rolled to select a rarity tier, and a random item is drawn from the [Class][Quality][Tier] bucket according to the rolled drop chance.  

Crafted Items and Quest Reward items that pass the `PopulateItemCandidatesAndProportions()` filters are ignored by this logic since their "drop rate" is effectively 100%.

### WIP concerns:  
1. Is this feature something you want added?
2. Are there extra config settings that should be exposed?
3. Does the probability selection logic need to be reworked? (i.e. The number of tiers and drop rate assigned to each is more or less arbitrarily assigned)
4. At the moment, this feature can yield AHs that have duplicates of "common" rare items, depending on ListProportion/MaxItems settings. I feel having the to-be-implemented duplicate item limiter could enhance this feature.

### Tests Performed:
- Builds without errors
- Verified many cached items' drop rates match expected in-game rates (according to DB)
- Verified there are no `ItemCandidatesByItemClassAndQuality` items without a corresponding drop rate
- Cycled >1,000,000 items through the AH without exceptions

### How to Test the Changes:
1. Enable AuctionHouseBot.Seller.UseDBDropRates.Enabled `(disabled by default)`
2. Clear and Re-populate auction house
3. Observe extremely rare weapons/armor/recipes occur less frequently (with additional logging to see bucket selection, items' drop rates correspond to their bucket's drop rate range)
