### PR TITLE
Added check to EmptyAuctionHouses() to prevent potential segfault

### DIFF
--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1589,6 +1589,12 @@ void AuctionHouseBot::InitializeConfiguration()
 
 void AuctionHouseBot::EmptyAuctionHouses()
 {
+    if (AHCharactersGUIDsForQuery.empty())
+    {
+        LOG_ERROR("module", "AuctionHouseBot: No character GUIDs found when emptying Auction Houses via '.ahbot empty' .");
+        return;
+    }
+
     struct AuctionInfo {
         uint32 itemID {0};
         uint32 characterGUID {0};


### PR DESCRIPTION
While trying a test with both Buyer and Seller disabled, I stumbled upon a segfault. This PR should catch that.  
Maybe `AHCharactersGUIDsForQuery` should try to be initialized even if Buyer and Seller are disabled?

### SOURCE:
```
// Get all auctions owned by AHBots
std::string queryString = "SELECT id, buyguid, houseid FROM auctionhouse WHERE itemowner IN ({})";
QueryResult result = CharacterDatabase.Query(queryString, AHCharactersGUIDsForQuery);
```  
If `AHCharactersGUIDsForQuery` is "", this causes the server to crash.

### Tests Performed:
- With both Seller and Buyer disabled, .ahbot empty gracefully does nothing, and logs an error to the console
- .ahbot update and .ahbot reload still work fine
