### PR TITLE
Added config to remove dangling expired/emptied auctions

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -39,6 +39,13 @@
 #        Enable/Disable the part of AHBot that puts items up for auction
 #    Default: false (disabled)
 #
+#    AuctionHouseBot.ReturnExpiredAuctionItemsToBot
+#        If enabled (true), returns expired auction items to the AH Bot(s) via
+#        mail. Note: if enabled, this can cause your bot's mailbox to fill up
+#        if you don't manage it manually. This can also cause the size of your
+#        acore_characters.item_instance database table to grow over time.
+#    Default: false (disabled)
+#
 #    AuctionHouseBot.GUIDs
 #        These are the character GUIDS (from characters->characters table) that
 #        will be used to create auctions and otherwise interact with auctions.
@@ -68,6 +75,7 @@ AuctionHouseBot.DEBUG_FILTERS = false
 AuctionHouseBot.MinutesBetweenBuyCycle = 1
 AuctionHouseBot.MinutesBetweenSellCycle = 1
 AuctionHouseBot.EnableSeller = false
+AuctionHouseBot.ReturnExpiredAuctionItemsToBot = false
 AuctionHouseBot.GUIDs = 0
 AuctionHouseBot.ItemsPerCycle = 150
 AuctionHouseBot.ListingExpireTimeInSecondsMin = 900

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1646,14 +1646,30 @@ void AuctionHouseBot::EmptyAuctionHouses()
             if (ai.characterGUID != 0)
                 sAuctionMgr->SendAuctionCancelledToBidderMail(auction,  trans);
 
-            // Remove item from AH
+            // Return item to AHBot if configured, else delete it
+            if (ReturnExpiredAuctionItemsToBot)
+            {
+                // Copied logic from AuctionHouseMgr.cpp::SendAuctionExpiredMail(), but not working as intended
+                //  For now, delete from DB so data doesn't build up unnecessarily
+                Item::DeleteFromDB(trans, auction->item_guid.GetCounter());
+
+                // Player* owner = ObjectAccessor::FindPlayer(auction->owner);
+                // Item* item = sAuctionMgr->GetAItem(auction->item_guid);
+                // owner->GetSession()->SendAuctionOwnerNotification(auction);
+                // MailDraft(auction->BuildAuctionMailSubject(AUCTION_EXPIRED), AuctionEntry::BuildAuctionMailBody(ObjectGuid::Empty, 0, auction->buyout, auction->deposit))
+                // .AddItem(item)
+                // .SendMailTo(trans, MailReceiver(owner, auction->owner.GetCounter()), auction, MAIL_CHECK_MASK_COPIED, 0);
+            }
+            else
+            {
+                Item::DeleteFromDB(trans, auction->item_guid.GetCounter());
+            }
+
+            // Remove auction from AH
             auction->DeleteFromDB(trans);
             sAuctionMgr->RemoveAItem(auction->item_guid);
             auctionHouse->RemoveAuction(auction);
 
-            // If we don't need to return the item to AHBot, delete it
-            if (!ReturnExpiredAuctionItemsToBot)
-                Item::DeleteFromDB(trans, auction->item_guid.GetCounter());
         }
     }
 

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1648,28 +1648,14 @@ void AuctionHouseBot::EmptyAuctionHouses()
 
             // Return item to AHBot if configured, else delete it
             if (ReturnExpiredAuctionItemsToBot)
-            {
-                // Copied logic from AuctionHouseMgr.cpp::SendAuctionExpiredMail(), but not working as intended
-                //  For now, delete from DB so data doesn't build up unnecessarily
-                Item::DeleteFromDB(trans, auction->item_guid.GetCounter());
-
-                // Player* owner = ObjectAccessor::FindPlayer(auction->owner);
-                // Item* item = sAuctionMgr->GetAItem(auction->item_guid);
-                // owner->GetSession()->SendAuctionOwnerNotification(auction);
-                // MailDraft(auction->BuildAuctionMailSubject(AUCTION_EXPIRED), AuctionEntry::BuildAuctionMailBody(ObjectGuid::Empty, 0, auction->buyout, auction->deposit))
-                // .AddItem(item)
-                // .SendMailTo(trans, MailReceiver(owner, auction->owner.GetCounter()), auction, MAIL_CHECK_MASK_COPIED, 0);
-            }
+                sAuctionMgr->SendAuctionExpiredMail(auction, trans, true, true);
             else
-            {
                 Item::DeleteFromDB(trans, auction->item_guid.GetCounter());
-            }
 
             // Remove auction from AH
             auction->DeleteFromDB(trans);
             sAuctionMgr->RemoveAItem(auction->item_guid);
             auctionHouse->RemoveAuction(auction);
-
         }
     }
 

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -128,6 +128,7 @@ private:
 
     bool SellingBotEnabled;
     bool BuyingBotEnabled;
+    bool ReturnExpiredAuctionItemsToBot;
     uint32 CyclesBetweenBuyActionMin;
     uint32 CyclesBetweenBuyAction;
     uint32 CyclesBetweenBuyActionMax;
@@ -322,6 +323,7 @@ public:
     void AddNewAuctions(std::vector<Player*> AHBPlayers, FactionSpecificAuctionHouseConfig* config);
     void AddNewAuctionBuyerBotBid(std::vector<Player*> AHBPlayers, FactionSpecificAuctionHouseConfig* config);
     void PopulateVendorItemsPrices();
+    void CleanupExpiredAuctionItems();
 
     template <typename ValueType>
     void AddItemValuePairsToItemIDMap(std::unordered_map<uint32, ValueType>& workingValueToItemIDMap, std::string valueToItemIDMap);

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -117,9 +117,17 @@ public:
         }
         if (isAHBot == true)
         {
-            if (sender.GetMailMessageType() == MAIL_AUCTION)        // auction mail with items
-                deleteMailItemsFromDB = true;
-            sendMail = false;
+            if (sConfigMgr->GetOption<bool>("AuctionHouseBot.ReturnExpiredAuctionItemsToBot", false))
+            {
+                deleteMailItemsFromDB = false;
+                sendMail = true;
+            }
+            else
+            {
+                if (sender.GetMailMessageType() == MAIL_AUCTION)        // auction mail with items
+                    deleteMailItemsFromDB = true;
+                sendMail = false;
+            }
         }
     }
 };

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -62,7 +62,7 @@ public:
         }
     }
 
-    void OnBeforeAuctionHouseMgrSendAuctionExpiredMail(AuctionHouseMgr* /*auctionHouseMgr*/, AuctionEntry* /*auction*/, Player* owner, uint32& /*owner_accId*/, bool& sendNotification, bool& /*sendMail*/) override
+    void OnBeforeAuctionHouseMgrSendAuctionExpiredMail(AuctionHouseMgr* /*auctionHouseMgr*/, AuctionEntry* /*auction*/, Player* owner, uint32& /*owner_accId*/, bool& sendNotification, bool& sendMail) override
     {
         if (owner)
         {
@@ -78,6 +78,11 @@ public:
             if (isAHBot == true)
             {
                 sendNotification = false;
+
+                if (sConfigMgr->GetOption<bool>("AuctionHouseBot.ReturnExpiredAuctionItemsToBot", false))
+                    sendMail = true;
+                else
+                    sendMail = false;
             }
         }   
     }


### PR DESCRIPTION
### Changes Proposed:
- `.ahbot empty` doesn't adhere to the usual auction lifecycle, so item_instances/mail can start to accumulate for the AHBot. This PR aims to address this.
  - Adds a config flag in case server admins want to maintain the current behavior (i.e. expired auction items are returned to the AHBot). 

### Issues Addressed:
After cycling >2,000,000 items through the Ah with `.ahbot update` and `.ahbot empty`, I noticed by backup files were becoming unusually large, with the `acore_characters.item_instance` table being >1GB. 

### Limitation
 - ~If `ReturnExpiredAuctionItemsToBot` is `true` and `.ahbot empty` is performed, I should think the items ought to be returned to the bot as if the auctions had expired naturally, but at the moment I haven't been able to get the example from AuctionHouseMgr.cpp::SendAuctionExpiredMail() to return items properly. In the meantime, the code deletes expired auctions to prevent data build-up for no reason.~ 
 - ~By chance are you familiar with how this flow is supposed to work?~

### Tests Performed:
- Verified the number of dangling auctions reduced to 0 after running the update
- Verified AHBot receives mail containing cancelled items with `ReturnExpiredAuctionItemsToBot` == true
- Verified AHBot does not receive mail when `ReturnExpiredAuctionItemsToBot` == false, and the number of dangling item_instances is 0

### How to Test the Changes:
1. Before pulling changes, add and remove many auctions with the `.ahbot` commands, and run the following query (replace the {} with your AHBot character ID) :  
```
SELECT *
FROM item_instance
LEFT JOIN auctionhouse ON auctionhouse.itemguid = item_instance.guid
WHERE item_instance.owner_guid IN ({})
AND auctionhouse.id IS NULL
```
2. There will likely be many rows -> each is an item that "exists" in the world, but is not in the auction house. Also, because these auctions didn't "expire" naturally, they weren't mailed back to the AHBot, so they're stuck in limbo.
3. After pulling the PR changes and ensuring `ReturnExpiredAuctionItemsToBot` is false, run `.ahbot update` , then re-run the above SQL query. The number of rows returned should be 0  

<br>

1. With `ReturnExpiredAuctionItemsToBot` == true, use `.ahbot empty` to cancel some items
2. Log into the AHBot character and observe mail delivery with cancelled items
